### PR TITLE
Fixed gif and image upload bug

### DIFF
--- a/src/components/sections/CreateBuzzForm/index.js
+++ b/src/components/sections/CreateBuzzForm/index.js
@@ -469,8 +469,10 @@ const CreateBuzzForm = (props) => {
 
   const handleSelectEmoticon = (emoticon) => {
     if (emoticon) {
-      const contentAppend = `${content}${emoticon}`
+      const contentAppend = `${!draftPost ? content : draftPost}${emoticon}`
       setContent(contentAppend)
+      savePostAsDraft(contentAppend)
+      savePostAsDraftToStorage(contentAppend)
     }
   }
 


### PR DESCRIPTION
Hi @stinkymonkeyph - I've found a bug in the current dev update. It's because of the new Draft Functionality. The problem is that currently we cannot able to add GIF, Emoji or Uploaded image into the Buzz due to the draft post function, we can see the uploaded image, GIF, or emoji in the MarkDown viewer but not in the text field. You can see the bug on Next.D.Buzz

So I fixed this issue in this PR. Kindly review and merge it into `dev`.