### PR TITLE
Added coin gecko to Buzz #393

### DIFF
--- a/src/components/common/MarkdownViewer/index.js
+++ b/src/components/common/MarkdownViewer/index.js
@@ -601,7 +601,7 @@ const render = (content, markdownClass, assetClass, scrollIndex, recomputeRowInd
     return <div
       key={`${new Date().getTime()}${scrollIndex}${Math.random()}`}
       className={classNames(markdownClass, assetClass)}
-      dangerouslySetInnerHTML={{ __html: renderer.render(content) }}
+      dangerouslySetInnerHTML={{ __html: renderer.render(content.replace(/\$([A-Za-z-]+)/gi, n => {return `<a href=https://www.coingecko.com/en/coins/${n.replace("$", '').toLowerCase()}/usd#panel>${n}</a>`})) }}
     />
   }
 


### PR DESCRIPTION
I've added functionality to convert $BITCOIN $FILECOIN $HIVE or any other coin name written with `$` to a CoinGecko price chart link. This will show in the Markdown Viewer.