### PR TITLE
Fix TikTok embeds so they play properly (#721)

### DIFF
--- a/src/components/common/MarkdownViewer/index.js
+++ b/src/components/common/MarkdownViewer/index.js
@@ -447,6 +447,7 @@ const prepareFacebookEmbeds = (content) => {
 
 const prepareTiktokEmbeds = (content) => {
   const tiktokRegex = /((http:\/\/(.*\.tiktok\.com\/.*|tiktok\.com\/.*))|(https:\/\/(.*\.tiktok\.com\/.*|tiktok\.com\/.*)))/g
+  const tiktokIdRegex = /[0-9]+/
 
   let body = content
   const links = textParser.getUrls(content)
@@ -458,10 +459,11 @@ const prepareTiktokEmbeds = (content) => {
 
     try {
       if(link.match(tiktokRegex)){
-        const data = link.split('/')
+        const url = new URL(link)
+        const data = url.pathname.split('/')
         match = link.match(tiktokRegex)
         
-        id = data[5]
+        id = data.reduce((a, v) => v.match(tiktokIdRegex) ? v : a)
       }
 
       if (!id) {
@@ -563,22 +565,24 @@ const render = (content, markdownClass, assetClass, scrollIndex, recomputeRowInd
     }
   } else if (content.includes(':tiktok:')) {
     const splitTiktok = content.split(':')
-    const url = `https://www.tiktok.com/embed/v2/${splitTiktok[2]}?lang=en-US`
-  
-    return (
-      <React.Fragment>
-        <div className={classes.tiktokWrapper}>
-          <iframe
-            title='Embedded Video'
-            src={url}
-            allowFullScreen={true}
-            frameBorder='0'
-            height='250'
-            width='100%'
-          ></iframe>
-        </div>
-      </React.Fragment>
-    )
+    if (splitTiktok[2]) {
+      const url = `https://www.tiktok.com/embed/v2/${splitTiktok[2]}?lang=en-US`
+
+      return (
+        <React.Fragment>
+          <div className={classes.tiktokWrapper}>
+            <iframe
+              title='Embedded Video'
+              src={url}
+              allowFullScreen={true}
+              frameBorder='0'
+              height='250'
+              width='100%'
+            ></iframe>
+          </div>
+        </React.Fragment>
+      )
+    }
   } else if (content.includes(':odysy:')) {
     const splitOdysy = content.split(':')
     const url = `https://odysee.com/$/embed/${splitOdysy[2]}`

--- a/src/components/sections/SearchPeople/index.js
+++ b/src/components/sections/SearchPeople/index.js
@@ -118,7 +118,7 @@ const SearchPeople = (props) => {
   return (
     <React.Fragment>
       {(items.people || []).map((item) => (
-        <div className={classes.wrapper}>
+        <div className={classes.wrapper} key={item.account}>
           <div className={classes.row}>
             <Link to={`/@${item.account}`}>
               <Row>


### PR DESCRIPTION
Changed the parsing of the URL to extract de TikTok video ID as it can appear in the pathname at different locations depending on the source of the URL (web or app).