### PR TITLE
Fixed username redirect to profile page #757

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -1,4 +1,4 @@
-import React from 'react'
+import React, { useEffect } from 'react'
 import routes from './routes'
 import { withRouter } from 'react-router'
 import { Init, AuthGuard, ThemeLoader } from 'components'
@@ -6,6 +6,7 @@ import { renderRoutes } from 'react-router-config'
 import { LastLocationProvider } from 'react-router-last-location'
 import { createUseStyles } from 'react-jss'
 import { Helmet } from 'react-helmet'
+import { redirectToUserProfile } from 'services/helper'
 
 const useStyles = createUseStyles(theme => ({
   wrapper: {
@@ -24,6 +25,12 @@ const AppWrapper = ({ children }) => {
 }
 
 const App = () => {
+
+  useEffect(() => {
+    // redirect to user profile if link only contains @username
+    redirectToUserProfile()
+  }, [])
+
   return (
     <React.Fragment>
       <Helmet>

--- a/src/services/helper.js
+++ b/src/services/helper.js
@@ -355,3 +355,10 @@ export const getDefaultVotingWeight = () => {
   }
   return 0
 }
+
+export const redirectToUserProfile = () => {
+  if(window.location.href.includes("@") && !window.location.href.includes("#/@")){
+    const account = window.location.href.split("@")
+    window.location = (`/#/@${account[1].replace("#/", "")}`)
+  }
+}


### PR DESCRIPTION
I've fixed this issue, Now `https://d.buzz/@username` will be forwarded to `https://d.buzz/#/@username`.

So it will be easy for users to visit others profile with just their `d.buzz/@username`.

Thanks @hivephilippines for pointing this out!