### PR TITLE
Ignore @ sign in the login modal #738

### DIFF
--- a/src/components/modals/LoginModal/index.js
+++ b/src/components/modals/LoginModal/index.js
@@ -105,7 +105,7 @@ const LoginModal = (props) => {
     const { name, value } = target
 
     if (name === 'username') {
-      setUsername(value)
+      setUsername(value.replace("@", ""))
     } else if (name === 'password') {
       setPassword(value)
     }


### PR DESCRIPTION
I've added a functionality so now users won't be able to add `@` sign in the Username field on Login Modal.

@hivephilippines @stinkymonkeyph 