### PR TITLE
Change cub coin ticker link #765

### DIFF
--- a/src/files/coinGeckoData.json
+++ b/src/files/coinGeckoData.json
@@ -8930,11 +8930,6 @@
 	  "name": "Cryptotipsfr"
 	},
 	{
-	  "id": "crypto-user-base",
-	  "symbol": "cub",
-	  "name": "Crypto User Base"
-	},
-	{
 	  "id": "cryptoverificationcoin",
 	  "symbol": "cvcc",
 	  "name": "CryptoVerificationCoin"


### PR DESCRIPTION
I've updated `$CUB` ticker link. Now it will redirect to the right link.

@hivephilippines @stinkymonkeyph 