### PR TITLE
Added DBuzz Explorer to MORE menu in the Professional Tools section

### DIFF
--- a/src/components/layout/MobileAppFrame/index.js
+++ b/src/components/layout/MobileAppFrame/index.js
@@ -1295,6 +1295,11 @@ const MobileAppFrame = (props) => {
                           </ListItem>
                         </List>
                         <List component="div">
+                          <ListItem component="a" href='https://dbuzz-explorer.netlify.app/' target="_blank" rel="noopener noreferrer" key='Explorer' button>
+                            <ListItemText primary='Explorer' />
+                          </ListItem>
+                        </List>
+                        <List component="div">
                           <ListItem component="a" href='https://d.buzz/leaderboard' target="_blank" rel="noopener noreferrer" key='Leaderboard' button>
                             <ListItemText primary='Leaderboard' />
                           </ListItem>


### PR DESCRIPTION
This code was added to the drop-down menu:

List component="div">
                          <ListItem component="a" href='https://dbuzz-explorer.netlify.app/' target="_blank" rel="noopener noreferrer" key='Explorer' button>
                            <ListItemText primary='Explorer' />
                          </ListItem>
                        </List>