### PR TITLE
Implement global moderation with moderator account mute list

### DIFF
--- a/src/config.js
+++ b/src/config.js
@@ -11,6 +11,7 @@ const config = {
   DISABLE_MOBILE: false,
   BRANCH: process.env.REACT_APP_ENV,
   DEFAULT_RPC_NODE: process.env.REACT_APP_DEFAULT_RPC_NODE,
+  MODERATOR_ACCOUNT: 'dbuzz', // Account whose mute list applies globally
   APP_NAME: 'D.Buzz',
   APP_DESCRIPTION: 'Micro-blogging social media Dapp on the HIVE blockchain.',
   APP_ICON: 'https://images.hive.blog/p/D5zH9SyxCKdAD9rYwjD1VDFVfes4J8WBmiaYPdeZndqBcsWCe3xdjZ9FWukYQcKxKMUaJu2FLm66h23z4KvAS7BxXaBpNLPzMVDqas4kKbBvZPf2zny6g2ePMPCmbC44pcvGUN?width=128&height=128',

--- a/src/services/api.js
+++ b/src/services/api.js
@@ -53,8 +53,16 @@ export const setRPCNode = async () => {
   }
 }
 
-export const invokeMuteFilter = (items, mutelist, opacityUsers = []) => {
-  return items.filter((item) => !mutelist.includes(item.author) || opacityUsers.includes(item.author))
+export const invokeMuteFilter = (items, mutelist, opacityUsers = [], globalMuteList = []) => {
+  return items.filter((item) => {
+    const isPersonallyMuted = mutelist.includes(item.author)
+    const isGloballyMuted = globalMuteList.includes(item.author)
+    const hasOpacity = opacityUsers.includes(item.author)
+
+    // Show post if: not muted at all, OR has opacity (personal mute visibility override)
+    // Global mutes cannot be overridden by opacity
+    return (!isPersonallyMuted && !isGloballyMuted) || (isPersonallyMuted && !isGloballyMuted && hasOpacity)
+  })
 }
 
 export const hashBuffer = (buffer) => {

--- a/src/store/auth/actions.js
+++ b/src/store/auth/actions.js
@@ -151,6 +151,13 @@ export const setMuteList = (response) => ({
   payload: response,
 })
 
+export const SET_GLOBAL_MUTE_LIST = 'SET_GLOBAL_MUTE_LIST'
+
+export const setGlobalMuteList = (response) => ({
+  type: SET_GLOBAL_MUTE_LIST,
+  payload: response,
+})
+
 export const MUTE_USER_REQUEST = 'MUTE_USER_REQUEST'
 export const MUTE_USER_FAILURE = 'MUTE_USER_FAILURE'
 export const MUTE_USER_SUCCESS = 'MUTE_USER_SUCCESS'

--- a/src/store/auth/reducers.js
+++ b/src/store/auth/reducers.js
@@ -5,6 +5,7 @@ import {
   SUBSCRIBE_SUCCESS,
   SET_FROM_LANDING,
   SET_MUTE_LIST,
+  SET_GLOBAL_MUTE_LIST,
   SET_HAS_PAYOUT_AGREED,
   SET_INTENT_BUZZ,
   CLEAR_INTENT_BUZZ,
@@ -22,6 +23,7 @@ const defaultState = fromJS({
   user: {},
   fromLanding: false,
   mutelist: [],
+  globalMuteList: [],
   payoutAgreed: false,
   opacityUsers: [],
   intentBuzz: {},
@@ -47,6 +49,8 @@ export const auth = (state = defaultState, { type, payload }) => {
     return state.set('fromLanding', payload)
   case SET_MUTE_LIST:
     return state.set('mutelist', payload)
+  case SET_GLOBAL_MUTE_LIST:
+    return state.set('globalMuteList', payload)
   case SET_HAS_PAYOUT_AGREED:
     return state.set('payoutAgreed', payload)
   case SET_INTENT_BUZZ:

--- a/src/store/auth/sagas.js
+++ b/src/store/auth/sagas.js
@@ -22,6 +22,7 @@ import {
   checkHasUpdateAuthorityFailure,
 
   setMuteList,
+  setGlobalMuteList,
 
   MUTE_USER_REQUEST,
   muteUserFailure,
@@ -325,6 +326,17 @@ function* getSavedUserRequest (meta) {
     
     // Censor API removed - no longer fetching censored list
     yield put(setCensorList([]))
+
+    // Fetch global mute list from moderator account
+    try {
+      const config = require('config').default
+      let globalMuteList = yield call(fetchMuteList, config.MODERATOR_ACCOUNT)
+      globalMuteList = [...new Set(globalMuteList.map(item => item.following))]
+      yield put(setGlobalMuteList(globalMuteList))
+    } catch(error) {
+      console.log('Failed to fetch global mute list:', error)
+      yield put(setGlobalMuteList([]))
+    }
 
     let payoutAgreed = yield call([localStorage, localStorage.getItem], 'payoutAgreed')
     

--- a/src/store/posts/sagas.js
+++ b/src/store/posts/sagas.js
@@ -165,8 +165,9 @@ function* getRepliesRequest(payload, meta) {
   try {
     if (!checkForCeramicAccount(author)) {
       const mutelist = yield select(state => state.auth.get('mutelist'))
+      const globalMuteList = yield select(state => state.auth.get('globalMuteList'))
       let replies = yield call(fetchDiscussions, author, permlink)
-      replies = invokeMuteFilter(replies, mutelist)
+      replies = invokeMuteFilter(replies, mutelist, [], globalMuteList)
       // console.log(replies)
       yield put(getRepliesSuccess(replies, meta))
     } else {
@@ -291,8 +292,9 @@ function* getTrendingPostsRequest(payload, meta) {
     data = data.filter(item => invokeFilter(item))
 
     const mutelist = yield select(state => state.auth.get('mutelist'))
+    const globalMuteList = yield select(state => state.auth.get('globalMuteList'))
     const opacityUsers = yield select(state => state.auth.get('opacityUsers'))
-    data = invokeMuteFilter(data, mutelist, opacityUsers)
+    data = invokeMuteFilter(data, mutelist, opacityUsers, globalMuteList)
     data = invokeHideBuzzFilter(data)
     data.map((item) => censorCheck(item, censoredList))
 
@@ -323,10 +325,11 @@ function* getHomePostsRequest(payload, meta) {
 
       yield put(setHomeLastPost(data[data.length - 1]))
       const mutelist = yield select(state => state.auth.get('mutelist'))
+      const globalMuteList = yield select(state => state.auth.get('globalMuteList'))
 
       data = data.filter(item => invokeFilter(item))
       const opacityUsers = yield select(state => state.auth.get('opacityUsers'))
-      data = invokeMuteFilter(data, mutelist, opacityUsers)
+      data = invokeMuteFilter(data, mutelist, opacityUsers, globalMuteList)
       data = invokeHideBuzzFilter(data)
       data.map((item) => censorCheck(item, censoredList))
 
@@ -371,9 +374,10 @@ function* getLatestPostsRequest(payload, meta) {
     data = data.filter(item => invokeFilter(item))
 
     const mutelist = yield select(state => state.auth.get('mutelist'))
+    const globalMuteList = yield select(state => state.auth.get('globalMuteList'))
     const opacityUsers = yield select(state => state.auth.get('opacityUsers'))
     const patterns = yield call(getMutePattern)
-    data = invokeMuteFilter(data, mutelist, opacityUsers)
+    data = invokeMuteFilter(data, mutelist, opacityUsers, globalMuteList)
     data = invokeHideBuzzFilter(data)
 
     data = patternMute(patterns, data)


### PR DESCRIPTION
This implements a platform-wide moderation feature where users muted by the official @dbuzz moderator account are hidden for all users.

Changes made:
- Added MODERATOR_ACCOUNT config (defaults to 'dbuzz')
- Added globalMuteList to Redux auth state
- Fetch moderator's mute list during app initialization
- Updated invokeMuteFilter to check both personal and global mutes
- Global mutes cannot be overridden by personal opacity settings
- Applied global mute filtering to all post feeds (home, trending, latest, replies)

Now any user muted by @dbuzz will have their posts hidden for all D.Buzz users, providing platform-level content moderation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)