### PR TITLE
Remove backend API dependencies - make app 100% front-end

### DIFF
--- a/src/components/layout/SideBarLeft/index.js
+++ b/src/components/layout/SideBarLeft/index.js
@@ -889,7 +889,7 @@ const SideBarLeft = (props) => {
               {
                 subtext: 'Leaderboard',
                 // icon: activeView === 'wallet' ? <WalletIcon type='fill'/> : <WalletIcon type='outline'/>,
-                subvisible: true,
+                subvisible: false,  // Disabled - requires backend API
                 subhref: 'https://d.buzz/leaderboard',
                 subonClick: '',
               },

--- a/src/components/modals/AddToPocketModal/index.js
+++ b/src/components/modals/AddToPocketModal/index.js
@@ -4,7 +4,7 @@ import ModalBody from 'react-bootstrap/ModalBody'
 import { createUseStyles } from 'react-jss'
 import { useState } from 'react'
 import { useEffect } from 'react'
-import { getUserCustomData, updateUserCustomData } from 'services/database/api'
+// Database API removed - using localStorage only
 import Spinner from 'components/elements/progress/Spinner'
 
 const useStyles = createUseStyles(theme => ({
@@ -194,14 +194,12 @@ function AddToPocketModal(props) {
 
   useEffect(() => {
     if(show) {
-      getUserCustomData(user.username)
-        .then(res => {
-          if(res[0].pockets) {
-            setPockets([...res[0].pockets])
-          } else {
-            setPockets([])
-          }
-        })
+      const customUserData = JSON.parse(localStorage.getItem('customUserData'))
+      if(customUserData?.pockets) {
+        setPockets([...customUserData.pockets])
+      } else {
+        setPockets([])
+      }
     }
     // eslint-disable-next-line
   }, [show])
@@ -240,22 +238,19 @@ function AddToPocketModal(props) {
 
   const addToPockets = () => {
     setLoading(true)
-    getUserCustomData(user.username)
-      .then((data) => {
-        // add buzz to the specified pocket
-        const pockets = data[0].pockets
-        pockets[selectedPocket.index].pocketBuzzes.push(buzz)
+    const customUserData = JSON.parse(localStorage.getItem('customUserData'))
+    // add buzz to the specified pocket
+    const pockets = customUserData.pockets
+    pockets[selectedPocket.index].pocketBuzzes.push(buzz)
 
-        // prepare data to be updated
-        const resData = { username: user.username, userData: [{username: data[0].username, settings: data[0].settings, pockets: [...pockets]}] }
+    // prepare data to be updated
+    const updatedData = {username: customUserData.username, settings: customUserData.settings, pockets: [...pockets]}
 
-        // update users's pockets data
-        updateUserCustomData(resData).then(() => {
-          setLoading(false)
-          setSelectedPocket(null)
-          onHide()
-        })
-      })
+    // update users's pockets data
+    localStorage.setItem('customUserData', JSON.stringify(updatedData))
+    setLoading(false)
+    setSelectedPocket(null)
+    onHide()
   }
 
   return (

--- a/src/components/modals/CreatePocketModal/index.js
+++ b/src/components/modals/CreatePocketModal/index.js
@@ -4,7 +4,7 @@ import ModalBody from 'react-bootstrap/ModalBody'
 import { createUseStyles } from 'react-jss'
 import { useState } from 'react'
 import { useEffect } from 'react'
-import { getUserCustomData, updateUserCustomData } from 'services/database/api'
+// Database API removed - using localStorage only
 import Spinner from 'components/elements/progress/Spinner'
 import CircularProgress from '@material-ui/core/CircularProgress'
 import moment from 'moment'
@@ -172,17 +172,20 @@ function CreatePocketModal(props) {
   useEffect(() => {
     if(show) {
       setFetching(true)
-      getUserCustomData(user.username)
-        .then(res => {
-          setUserData(res)
-          setFetching(false)
+      const customUserData = JSON.parse(localStorage.getItem('customUserData'))
+      if (customUserData) {
+        setUserData([customUserData])
+        setFetching(false)
 
-          if(res[0]?.pockets) {
-            res[0].pockets.forEach((pocket) => {
-              setPocketNames(pocketNames => [...pocketNames, pocket.pocketName])
-            })
-          }
-        })
+        if(customUserData?.pockets) {
+          customUserData.pockets.forEach((pocket) => {
+            setPocketNames(pocketNames => [...pocketNames, pocket.pocketName])
+          })
+        }
+      } else {
+        setUserData([{}])
+        setFetching(false)
+      }
     }
     // eslint-disable-next-line
   }, [show])
@@ -220,19 +223,14 @@ function CreatePocketModal(props) {
       // 	pocketBuzzes: []
       // }
   
-      const customUserData = { username: user.username, userData: [{...userData[0], pockets}] }
-      updateUserCustomData(customUserData).then(() => {
-        loadPockets(pocketSlug)
-        setPocketName('')
-        setPocketSlug('')
-        setLoading(false)
-        onHide(!true)
-        setTryAgain(false)
-      })
-        .catch(() => {
-          setLoading(false)
-          setTryAgain(true)
-        })
+      const updatedData = {...userData[0], pockets}
+      localStorage.setItem('customUserData', JSON.stringify(updatedData))
+      loadPockets(pocketSlug)
+      setPocketName('')
+      setPocketSlug('')
+      setLoading(false)
+      onHide(!true)
+      setTryAgain(false)
   
       // setUserData(data => [{...data[0], pockets}])
     } else {

--- a/src/components/modals/RemoveFromPocketConfirmModal/index.js
+++ b/src/components/modals/RemoveFromPocketConfirmModal/index.js
@@ -4,7 +4,7 @@ import ModalBody from 'react-bootstrap/ModalBody'
 import { createUseStyles } from 'react-jss'
 import { useState } from 'react'
 import { useEffect } from 'react'
-import { getUserCustomData, updateUserCustomData } from 'services/database/api'
+// Database API removed - using localStorage only
 import Spinner from 'components/elements/progress/Spinner'
 import { CircularProgress } from '@material-ui/core'
 
@@ -126,12 +126,16 @@ function RemoveFromPocketConfirmModal(props) {
   useEffect(() => {
     if(show) {
       setFetching(true)
-      getUserCustomData(user.username)
-        .then(res => {
-          setUserData(res[0])
-          setPockets([...res[0].pockets])
-          setFetching(false)
-        })
+      const customUserData = JSON.parse(localStorage.getItem('customUserData'))
+      if (customUserData) {
+        setUserData(customUserData)
+        setPockets([...customUserData.pockets])
+        setFetching(false)
+      } else {
+        setUserData({})
+        setPockets([])
+        setFetching(false)
+      }
     }
     // eslint-disable-next-line
   }, [show])
@@ -157,16 +161,15 @@ function RemoveFromPocketConfirmModal(props) {
     pockets[pocketIndex].pocketBuzzes = [...pocketBuzzesArray]
     
     // prepare data to be updated
-    const customUserData = { username: user.username, userData: [{...userData, pockets: pocketsArray}] }
+    const updatedData = {...userData, pockets: pocketsArray}
 
-    updateUserCustomData(customUserData).then(() => {
-      setLoading(false)
-      onCancel()
-      
-      if(loadPockets) {
-        loadPockets(pocket.pocketSlug)
-      }
-    })
+    localStorage.setItem('customUserData', JSON.stringify(updatedData))
+    setLoading(false)
+    onCancel()
+
+    if(loadPockets) {
+      loadPockets(pocket.pocketSlug)
+    }
   }
 
   const onCancel = () => {

--- a/src/components/modals/SettingsModal/index.js
+++ b/src/components/modals/SettingsModal/index.js
@@ -7,7 +7,6 @@ import config from 'config'
 import { checkVersionRequest } from 'store/settings/actions'
 import { connect } from 'react-redux'
 import { bindActionCreators } from 'redux'
-import { getUserCustomData, updateUserCustomData } from 'services/database/api'
 import { CircularProgress } from '@material-ui/core'
 import { setRPCNode } from 'services/api'
 import { hiveAPIUrls } from 'services/helper'
@@ -242,25 +241,14 @@ const SettingsModal = (props) => {
 
   const handleUpdateSettings = () => {
     setLoading(true)
-    const { username } = user
-    getUserCustomData(username).then(res => {
-      const userData = {...res[0], settings: {
-        ...res[0].settings,
-        videoEmbedsStatus: JSON.parse(localStorage.getItem('customUserData'))?.settings?.videoEmbedsStatus,
-        linkPreviewsStatus: JSON.parse(localStorage.getItem('customUserData'))?.settings?.linkPreviewsStatus,
-        showImagesStatus: JSON.parse(localStorage.getItem('customUserData'))?.settings?.showImagesStatus,
-        showNSFWPosts: JSON.parse(localStorage.getItem('customUserData'))?.settings?.showNSFWPosts,
-      }}
-      const responseData = { username: username, userData: [userData] }
-      if(res) {
-        updateUserCustomData(responseData).then(() => {
-          setSelectedItem(null)
-          setLoading(false)
-          handleDisableEnableToggles(true)
-          window.location.reload()
-        })
-      }
-    })
+    // Settings are already saved to localStorage via useEffect
+    // Just reload the page to apply changes
+    setTimeout(() => {
+      setSelectedItem(null)
+      setLoading(false)
+      handleDisableEnableToggles(true)
+      window.location.reload()
+    }, 500)
   }
 
   const handleVideoEmbedsToggle = () => {

--- a/src/components/modals/ThemeModal/index.js
+++ b/src/components/modals/ThemeModal/index.js
@@ -8,7 +8,6 @@ import { getTheme } from 'services/theme'
 import { setThemeRequest, generateStyles } from 'store/settings/actions'
 import { connect } from 'react-redux'
 import { bindActionCreators } from 'redux'
-import { getUserCustomData, updateUserCustomData } from 'services/database/api'
 import { CircularProgress } from '@material-ui/core'
 
 const useStyles = createUseStyles(theme => ({
@@ -139,27 +138,11 @@ const ThemeModal = (props) => {
   }
   
   const handleUpdateTheme = (theme) => {
-    const { username } = user
-    
-    getUserCustomData(username)
-      .then(res => {
-        const userData = {
-          ...res[0],
-          settings: {
-            ...res[0].settings,
-            theme: theme,
-          },
-        }
-        const responseData = { username, userData: [userData] }
-        
-        if(res) {
-          updateUserCustomData(responseData)
-            .then(() => {
-              setLoading(false)
-            })
-        }
-      })
-
+    // Theme is already saved to localStorage in handleSetTheme
+    // Just finish loading state
+    setTimeout(() => {
+      setLoading(false)
+    }, 300)
   }
 
   return (

--- a/src/components/sections/AccountPockets/index.js
+++ b/src/components/sections/AccountPockets/index.js
@@ -5,7 +5,7 @@ import { createUseStyles } from 'react-jss'
 import Add from '@material-ui/icons/Add'
 import { IconButton, Menu, MenuItem, Snackbar, Tab, Tabs } from '@material-ui/core'
 import CreatePocketModal from 'components/modals/CreatePocketModal'
-import { getUserCustomData, updateUserCustomData } from 'services/database/api'
+// Database API removed - using localStorage only
 import Tooltip from '@material-ui/core/Tooltip'
 import ExpandMoreRoundedIcon from '@material-ui/icons/ExpandMoreRounded'
 import KeyboardArrowUpRoundedIcon from '@material-ui/icons/KeyboardArrowUpRounded'
@@ -245,26 +245,25 @@ const AccountsPockets = (props) => {
   
   const loadPockets = (slug) => {
     setLoading(true)
-    getUserCustomData(author)
-      .then(res => {
-        if(res[0]?.pockets?.length > 0) {
-          // if has slug thenfind index else the index is 0
-          const index = res[0].pockets.findIndex(obj => obj.pocketSlug === slug) >= 0 ? res[0].pockets.findIndex(obj => obj.pocketSlug === slug) : 0
+    // Get data from localStorage
+    const customUserData = JSON.parse(localStorage.getItem('customUserData'))
+    if(customUserData?.pockets?.length > 0) {
+      // if has slug then find index else the index is 0
+      const index = customUserData.pockets.findIndex(obj => obj.pocketSlug === slug) >= 0 ? customUserData.pockets.findIndex(obj => obj.pocketSlug === slug) : 0
 
-          setUserData(res[0])
-          setPockets([...res[0].pockets])
-          setSelectedPocket({index, id: res[0].pockets[index].pocketId, name: res[0].pockets[index].pocketName, slug: res[0].pockets[index].pocketSlug})
-          setPocketBuzzes(res[0].pockets[index]?.pocketBuzzes.reverse())
-          updatePocketRoute(res[0].pockets[index].pocketSlug)
-          setLoading(false)
-        } else {
-          setPockets([])
-          setSelectedPocket({index: 0})
-          setPocketBuzzes([])
-          updatePocketRoute()
-          setLoading(false)
-        }
-      })
+      setUserData(customUserData)
+      setPockets([...customUserData.pockets])
+      setSelectedPocket({index, id: customUserData.pockets[index].pocketId, name: customUserData.pockets[index].pocketName, slug: customUserData.pockets[index].pocketSlug})
+      setPocketBuzzes(customUserData.pockets[index]?.pocketBuzzes.reverse())
+      updatePocketRoute(customUserData.pockets[index].pocketSlug)
+      setLoading(false)
+    } else {
+      setPockets([])
+      setSelectedPocket({index: 0})
+      setPocketBuzzes([])
+      updatePocketRoute()
+      setLoading(false)
+    }
   }
 
   useEffect(() => {
@@ -301,11 +300,10 @@ const AccountsPockets = (props) => {
       pocketsArray.splice(pocketIndex, 1)
     }
 
-	  const customUserData = { username: user.username, userData: [{...userData, pockets: pocketsArray}] }
-
-    updateUserCustomData(customUserData).then(() => {
-      loadPockets(selectedPocket.slug)
-    })
+    // Update localStorage
+    const customUserData = {...userData, pockets: pocketsArray}
+    localStorage.setItem('customUserData', JSON.stringify(customUserData))
+    loadPockets(selectedPocket.slug)
   }
 
   const handleOnClickDeletePocket = () => {

--- a/src/components/sections/PostList/index.js
+++ b/src/components/sections/PostList/index.js
@@ -36,7 +36,7 @@ import Chip from '@material-ui/core/Chip'
 import { sendToBerries, censorLinks } from 'services/helper'
 import Renderer from 'components/common/Renderer'
 import AddToPocketModal from 'components/modals/AddToPocketModal'
-import { getUserCustomData } from 'services/database/api'
+// Database API removed - using localStorage only
 import RemoveFromPocketConfirmModal from 'components/modals/RemoveFromPocketConfirmModal'
 
 const addHover = (theme) => {
@@ -326,14 +326,13 @@ const PostList = React.memo((props) => {
 
   useEffect(() => {
     if(anchorEl !== null) {
-      getUserCustomData(user.username)
-        .then(res => {
-          if(res[0].pockets) {
-            setPockets([...res[0].pockets])
-          } else {
-            setPockets([])
-          }
-        })
+      // Get pockets from localStorage
+      const customUserData = JSON.parse(localStorage.getItem('customUserData'))
+      if(customUserData?.pockets) {
+        setPockets([...customUserData.pockets])
+      } else {
+        setPockets([])
+      }
     }
     // eslint-disable-next-line
   }, [anchorEl])

--- a/src/components/wrappers/AuthGuard/index.js
+++ b/src/components/wrappers/AuthGuard/index.js
@@ -1,7 +1,6 @@
 import React, { useEffect } from 'react'
 import { connect } from 'react-redux'
 import { useLocation, Redirect } from 'react-router-dom'
-import { getUserCustomData, initilizeUserInDatabase } from 'services/database/api'
 
 const AuthGuard = (props) => {
   const { children, user, fromLanding } = props
@@ -17,24 +16,29 @@ const AuthGuard = (props) => {
     return  pathname.match(/^(\/trending)/g)
   }
 
-  // DECENTRALIZED DATABASE
+  // LOCAL STORAGE - Front-end only, no backend database
 
   useEffect(() => {
     const { username } = user
 
     if(username) {
-      getUserCustomData(username).then(data => {
-        if(data !== 'User not found') {
-          localStorage.setItem('customUserData', JSON.stringify(...data))
-        } else {
-          // initialize datbase here
-          initilizeUserInDatabase(username).then(() => {
-            console.log('new user initialized')
-          })
+      // Initialize user settings in localStorage if not present
+      const existingData = localStorage.getItem('customUserData')
+      if (!existingData) {
+        const defaultSettings = {
+          username: username,
+          settings: {
+            theme: 'light',
+            videoEmbedsStatus: 'enabled',
+            linkPreviewsStatus: 'enabled',
+            showImagesStatus: 'enabled',
+            showNSFWPosts: 'disabled'
+          }
         }
-      })
+        localStorage.setItem('customUserData', JSON.stringify(defaultSettings))
+        console.log('New user settings initialized in localStorage')
+      }
     } else {
-      
       // guest
       console.log('%c[CURRENT SESSION]: ', 'color: goldenrod', 'Logged Out')
     }

--- a/src/components/wrappers/AuthGuard/index.js
+++ b/src/components/wrappers/AuthGuard/index.js
@@ -32,8 +32,8 @@ const AuthGuard = (props) => {
             videoEmbedsStatus: 'enabled',
             linkPreviewsStatus: 'enabled',
             showImagesStatus: 'enabled',
-            showNSFWPosts: 'disabled'
-          }
+            showNSFWPosts: 'disabled',
+          },
         }
         localStorage.setItem('customUserData', JSON.stringify(defaultSettings))
         console.log('New user settings initialized in localStorage')

--- a/src/routes.js
+++ b/src/routes.js
@@ -5,7 +5,8 @@ const GetStarted = React.lazy(() => import('./components/pages/GetStarted'))
 const Home = React.lazy(() => import('./components/pages/Home'))
 const Trending = React.lazy(() => import('./components/pages/Trending'))
 const FAQs = React.lazy(() => import('./components/pages/FAQs'))
-const Leaderboard = React.lazy(() => import('./components/pages/Leaderboard'))
+// Leaderboard disabled - requires backend API
+// const Leaderboard = React.lazy(() => import('./components/pages/Leaderboard'))
 const Profile = React.lazy(() => import('./components/pages/Profile'))
 const Content = React.lazy(() => import('./components/pages/Content'))
 const Latest = React.lazy(() => import('./components/pages/Latest'))
@@ -104,11 +105,12 @@ const routes =  [
         exact: true,
         component: FAQs,
       },
-      {
-        path: '/leaderboard',
-        exact: true,
-        component: Leaderboard,
-      },
+      // Leaderboard disabled - requires backend API
+      // {
+      //   path: '/leaderboard',
+      //   exact: true,
+      //   component: Leaderboard,
+      // },
       {
         path: '/ug/search',
         component: Search,

--- a/src/services/api.js
+++ b/src/services/api.js
@@ -1412,20 +1412,17 @@ export const getLinkMeta = (url) => {
 }
 
 export const checkVersion = () => {
+  // Backend removed - always return current version as latest
   return new Promise((resolve) => {
-    axios.get('https://endpoint.d.buzz/version.json')
-      .then(function (result) {
-        resolve(result.data)
-      })
+    const { BRANCH, VERSION } = appConfig
+    resolve({ [BRANCH]: VERSION })
   })
 }
 
 export const getMutePattern = () => {
+  // Backend removed - return empty pattern array
   return new Promise((resolve) => {
-    axios.get('https://endpoint.d.buzz/pattern.json')
-      .then(function (result) {
-        resolve(result.data)
-      })
+    resolve([])
   })
 }
 


### PR DESCRIPTION
This commit removes all dependencies on the d.buzz backend API (endpoint.d.buzz), making the app a fully front-end application that only uses Hive blockchain endpoints.

Changes made:
- Replace all database API calls with localStorage
- User settings (theme, video embeds, link previews, etc.) now stored locally
- Pockets feature now uses localStorage instead of backend
- Remove leaderboard feature (requires backend aggregation)
- Update checkVersion() to always return current version
- Update getMutePattern() to return empty array
- Fix CORS errors by eliminating endpoint.d.buzz API calls

This resolves network errors and CORS policy violations when accessing the backend API. All user data is now stored locally in the browser.

🤖 Generated with [Claude Code](https://claude.com/claude-code)