### PR TITLE
Remove CORS-blocked Hive APIs from failover list

### DIFF
--- a/src/services/helper.js
+++ b/src/services/helper.js
@@ -645,12 +645,7 @@ export const calculateAverageRanking = (users) => {
 }
 
 export const hiveAPIUrls = [
-  "https://hive-api.3speak.tv",
-  "https://rpc.mahdiyari.info",
-  "https://anyx.io",
-  "https://api.deathwing.me",
-  "https://hived.emre.sh",
   "https://api.openhive.network",
-  "https://techcoderx.com",
-  "https://api.c0ff33a.uk",
+  "https://hived.emre.sh",
+  "https://api.deathwing.me",
 ]


### PR DESCRIPTION
Removed Hive API nodes that don't support CORS, which caused network errors and blocked requests from the browser.

Removed APIs (CORS issues):
- https://rpc.mahdiyari.info (CORS blocked)
- https://anyx.io (connection failures)
- https://hive-api.3speak.tv (CORS issues)
- https://techcoderx.com (unreliable)
- https://api.c0ff33a.uk (CORS issues)

Kept working APIs:
1. https://api.hive.blog (default - official Hive)
2. https://api.openhive.network (reliable, CORS enabled)
3. https://hived.emre.sh (reliable, CORS enabled)
4. https://api.deathwing.me (reliable, CORS enabled)

This reduces console errors and improves connection reliability by only using APIs that properly support browser requests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)