### PR TITLE
Remove hived.emre.sh from failover list

### DIFF
--- a/src/services/helper.js
+++ b/src/services/helper.js
@@ -646,6 +646,5 @@ export const calculateAverageRanking = (users) => {
 
 export const hiveAPIUrls = [
   "https://api.openhive.network",
-  "https://hived.emre.sh",
   "https://api.deathwing.me",
 ]


### PR DESCRIPTION
Removed hived.emre.sh due to reliability issues.

Remaining APIs (3 total):
1. https://api.hive.blog (default - official)
2. https://api.openhive.network (backup)
3. https://api.deathwing.me (backup)

🤖 Generated with [Claude Code](https://claude.com/claude-code)