### PR TITLE
Fix API priority to always prefer api.hive.blog first

### DIFF
--- a/src/services/api.js
+++ b/src/services/api.js
@@ -31,6 +31,9 @@ const failedAPIs = new Map() // Track failed APIs with timestamps
 const API_COOLDOWN_MS = 5 * 60 * 1000 // 5 minutes cooldown for failed APIs
 const allHiveAPIs = [defaultNode, ...hiveAPIUrls]
 
+// Log the API list on initialization
+console.log('Hive API failover initialized with priority order:', allHiveAPIs)
+
 // Get list of available (not recently failed) APIs
 const getAvailableAPIs = () => {
   const now = Date.now()
@@ -49,22 +52,28 @@ const getAvailableAPIs = () => {
 // Mark API as failed
 const markAPIAsFailed = (apiUrl) => {
   failedAPIs.set(apiUrl, Date.now())
-  console.warn(`Marked API as failed: ${apiUrl}. Will retry after cooldown.`)
+  console.warn(`❌ Marked API as failed: ${apiUrl}. Will retry after cooldown.`)
 }
 
 // Get next available API - always tries in priority order
 const getNextAvailableAPI = () => {
   const available = getAvailableAPIs()
+
+  console.log('Available APIs:', available)
+  console.log('Failed APIs:', Array.from(failedAPIs.keys()))
+
   if (available.length === 0) {
     // All APIs failed, clear the failed list and start over
-    console.warn('All Hive APIs failed, resetting and retrying...')
+    console.warn('⚠️ All Hive APIs failed, resetting and retrying...')
     failedAPIs.clear()
     return allHiveAPIs[0]
   }
 
   // Always return the first available API (priority order)
   // Priority: api.hive.blog -> api.openhive.network -> api.deathwing.me
-  return available[0]
+  const selectedAPI = available[0]
+  console.log(`✅ Selected API (priority order): ${selectedAPI}`)
+  return selectedAPI
 }
 
 export const getActiveRPCNode = () => {
@@ -82,12 +91,12 @@ export const setRPCNode = async () => {
     const node = getActiveRPCNode()
     if (api && typeof api.setOptions === 'function') {
       api.setOptions({ url: node })
-      console.log(`Connected to Hive API: ${node}`)
+      console.log(`🔗 Connected to Hive API: ${node}`)
     } else {
       throw new Error('API object or setOptions method is not available')
     }
   } catch (error) {
-    console.error('Error setting RPC node:', error)
+    console.error('❌ Error setting RPC node:', error)
     const currentNode = getActiveRPCNode()
     markAPIAsFailed(currentNode)
 
@@ -96,10 +105,10 @@ export const setRPCNode = async () => {
       const nextNode = getNextAvailableAPI()
       if (api && typeof api.setOptions === 'function') {
         api.setOptions({ url: nextNode })
-        console.log(`Switched to backup Hive API: ${nextNode}`)
+        console.log(`🔄 Switched to backup Hive API: ${nextNode}`)
       }
     } catch (fallbackError) {
-      console.error('Failed to set backup RPC node:', fallbackError)
+      console.error('❌ Failed to set backup RPC node:', fallbackError)
     }
   }
 }

--- a/src/services/api.js
+++ b/src/services/api.js
@@ -27,7 +27,6 @@ const visited = []
 const defaultNode = appConfig.DEFAULT_RPC_NODE
 
 // Failover system for Hive APIs
-let currentRPCIndex = 0
 const failedAPIs = new Map() // Track failed APIs with timestamps
 const API_COOLDOWN_MS = 5 * 60 * 1000 // 5 minutes cooldown for failed APIs
 const allHiveAPIs = [defaultNode, ...hiveAPIUrls]
@@ -53,21 +52,19 @@ const markAPIAsFailed = (apiUrl) => {
   console.warn(`Marked API as failed: ${apiUrl}. Will retry after cooldown.`)
 }
 
-// Get next available API in rotation
+// Get next available API - always tries in priority order
 const getNextAvailableAPI = () => {
   const available = getAvailableAPIs()
   if (available.length === 0) {
     // All APIs failed, clear the failed list and start over
     console.warn('All Hive APIs failed, resetting and retrying...')
     failedAPIs.clear()
-    currentRPCIndex = 0
     return allHiveAPIs[0]
   }
 
-  // Rotate through available APIs
-  const api = available[currentRPCIndex % available.length]
-  currentRPCIndex++
-  return api
+  // Always return the first available API (priority order)
+  // Priority: api.hive.blog -> api.openhive.network -> api.deathwing.me
+  return available[0]
 }
 
 export const getActiveRPCNode = () => {


### PR DESCRIPTION
Changed failover logic from round-robin rotation to priority-based selection. Now always tries APIs in priority order instead of rotating through them.

Before (round-robin):
- Call 1: api.hive.blog
- Call 2: api.openhive.network
- Call 3: api.deathwing.me
- Call 4: api.hive.blog (back to start)

After (priority-based):
- Every call: tries api.hive.blog first (if not failed)
- Only uses backups if primary is marked as failed
- Returns to primary after 5-minute cooldown

Priority order:
1. https://api.hive.blog (always tried first)
2. https://api.openhive.network (if #1 failed)
3. https://api.deathwing.me (if #1 and #2 failed)

This ensures the official Hive API is always preferred and backup APIs are only used when the primary fails.

🤖 Generated with [Claude Code](https://claude.com/claude-code)