### PR TITLE
Fix TypeError: n.filter is not a function

### DIFF
--- a/src/services/api.js
+++ b/src/services/api.js
@@ -185,6 +185,13 @@ export const callBridge = async (method, params, appendParams = true) => {
         if (err) {
           reject(err)
         } else {
+          // Ensure data is an array
+          if (!Array.isArray(data)) {
+            console.error('callBridge received non-array data:', data)
+            resolve([])
+            return
+          }
+
           let lastResult = []
 
           if (data.length !== 0) {
@@ -349,6 +356,13 @@ export const fetchAccountPosts = (account, start_permlink = null, start_author =
       if (err) {
         reject(err)
       } else {
+        // Ensure data is an array
+        if (!Array.isArray(data)) {
+          console.error('fetchAccountPosts received non-array data:', data)
+          resolve([])
+          return
+        }
+
         removeFootNote(data)
 
         let lastResult = []
@@ -357,7 +371,7 @@ export const fetchAccountPosts = (account, start_permlink = null, start_author =
           lastResult = [data[data.length - 1]]
         }
 
-        let posts = typeof data !== 'string' ? data.filter((item) => invokeFilter(item)) : []
+        let posts = data.filter((item) => invokeFilter(item))
 
         posts = [...posts, ...lastResult]
 


### PR DESCRIPTION
Fixed crash when API returns non-array data by adding proper validation before calling .filter() method.

Issue:
- Home page crashed with "TypeError: n.filter is not a function"
- This occurred when Hive API returned unexpected data format
- Code assumed data was always an array without validation

Fixed in:
1. callBridge() - Added Array.isArray() check before filtering
2. fetchAccountPosts() - Added Array.isArray() check and improved validation

Changes:
- Added Array.isArray() validation before calling .filter()
- Return empty array [] when data is not an array
- Log error to console for debugging
- Prevents app crash and shows empty content instead

Now handles edge cases:
- API returns string instead of array
- API returns object instead of array
- API returns null/undefined
- Network errors that return unexpected formats

🤖 Generated with [Claude Code](https://claude.com/claude-code)