### PR TITLE
Debug Mute User Button Functionality

### DIFF
--- a/src/components/modals/BlacklistModal/index.js
+++ b/src/components/modals/BlacklistModal/index.js
@@ -203,7 +203,7 @@ const BlacklistModal = (props) => {
 
 const mapStateToProps = (state) => ({
   theme: state.settings.get('theme'),
-  blacklistModal: state.interfaces.get('blacklistDialog'),
+  blacklistModal: state.interfaces.get('blacklistDialog')?.toJS ? state.interfaces.get('blacklistDialog').toJS() : state.interfaces.get('blacklistDialog'),
   loading: pending(state, 'BLACKLIST_USER_REQUEST') || pending(state, 'UNBLACKLIST_USER_REQUEST'),
   blacklistedList: state.profile.get('blacklistedList'),
 })

--- a/src/components/modals/CensorshipModal/index.js
+++ b/src/components/modals/CensorshipModal/index.js
@@ -200,7 +200,7 @@ const CensorhipModal = (props) => {
 }
 
 const mapStateToProps = (state) => ({
-  item: state.interfaces.get('censorshipDialog'),
+  item: state.interfaces.get('censorshipDialog')?.toJS ? state.interfaces.get('censorshipDialog').toJS() : state.interfaces.get('censorshipDialog'),
   censorTypes: [],
   loading: false,
 })

--- a/src/components/modals/FollowBlacklistsModal/index.js
+++ b/src/components/modals/FollowBlacklistsModal/index.js
@@ -234,7 +234,7 @@ const FollowBlacklistsModal = (props) => {
 
 const mapStateToProps = (state) => ({
   theme: state.settings.get('theme'),
-  followBlacklistsDialog: state.interfaces.get('followBlacklistsDialog'),
+  followBlacklistsDialog: state.interfaces.get('followBlacklistsDialog')?.toJS ? state.interfaces.get('followBlacklistsDialog').toJS() : state.interfaces.get('followBlacklistsDialog'),
   loading: pending(state, 'FOLLOW_BLACKLISTS_REQUEST') || pending(state, 'UNFOLLOW_BLACKLISTS_REQUEST'),
   followedBlacklist: state.profile.get('followedBlacklist'),
 })

--- a/src/components/modals/FollowMutedListModal/index.js
+++ b/src/components/modals/FollowMutedListModal/index.js
@@ -234,7 +234,7 @@ const FollowMutedListModal = (props) => {
 
 const mapStateToProps = (state) => ({
   theme: state.settings.get('theme'),
-  followMutedModal: state.interfaces.get('followMutedListDialog'),
+  followMutedModal: state.interfaces.get('followMutedListDialog')?.toJS ? state.interfaces.get('followMutedListDialog').toJS() : state.interfaces.get('followMutedListDialog'),
   loading: pending(state, 'FOLLOW_MUTED_LIST_REQUEST') || pending(state, 'UNFOLLOW_MUTED_LIST_REQUEST'),
   followedMutedList: state.profile.get('followedMuted'),
 })

--- a/src/components/modals/HideBuzzModal/index.js
+++ b/src/components/modals/HideBuzzModal/index.js
@@ -175,7 +175,7 @@ const HideBuzzModal = (props) => {
 
 const mapStateToProps = (state) => ({
   theme: state.settings.get('theme'),
-  hideBuzzDialog: state.interfaces.get('hideBuzzDialog'),
+  hideBuzzDialog: state.interfaces.get('hideBuzzDialog')?.toJS ? state.interfaces.get('hideBuzzDialog').toJS() : state.interfaces.get('hideBuzzDialog'),
   loading: pending(state, 'HIDE_BUZZ_REQUEST'),
   mutelist: state.auth.get('mutelist'),
 })

--- a/src/components/modals/MuteModal/index.js
+++ b/src/components/modals/MuteModal/index.js
@@ -248,7 +248,7 @@ const MuteModal = (props) => {
 
 const mapStateToProps = (state) => ({
   theme: state.settings.get('theme'),
-  muteModal: state.interfaces.get('muteDialogUser'),
+  muteModal: state.interfaces.get('muteDialogUser')?.toJS ? state.interfaces.get('muteDialogUser').toJS() : state.interfaces.get('muteDialogUser'),
   loading: pending(state, 'MUTE_USER_REQUEST'),
   mutelist: state.auth.get('mutelist'),
 })


### PR DESCRIPTION
The mute user button and several other dialog modals were not working because they were trying to access Immutable Map objects using standard JavaScript object methods (.hasOwnProperty() and destructuring), which don't work with Immutable Maps.

Fixed modals:
- MuteModal: Mute/unmute user functionality
- HideBuzzModal: Hide buzz functionality
- FollowMutedListModal: Follow/unfollow muted lists
- BlacklistModal: Blacklist/unblacklist user functionality
- FollowBlacklistsModal: Follow/unfollow blacklists
- CensorshipModal: Censorship dialog functionality

The fix adds a conditional check in mapStateToProps to convert Immutable Maps to plain JavaScript objects using .toJS() when available, ensuring all modals can properly access and destructure the dialog state.

🤖 Generated with [Claude Code](https://claude.com/claude-code)