### PR TITLE
Fix PrivateKey class instantiation with new keyword

### DIFF
--- a/src/services/api.js
+++ b/src/services/api.js
@@ -1565,7 +1565,7 @@ export const uploadImageToHiveBlog = async (data, username, postingKey, progress
 
           // Sign the hash with posting private key
           console.log('[HIVE UPLOAD] Signing with posting key...')
-          const privateKey = PrivateKey.fromString ? PrivateKey.fromString(postingKey) : PrivateKey(postingKey)
+          const privateKey = PrivateKey.fromString ? PrivateKey.fromString(postingKey) : new PrivateKey(postingKey)
           console.log('[HIVE UPLOAD] Private key created:', !!privateKey)
           const signature = privateKey.sign(Buffer.from(imageHash)).toString()
           console.log('[HIVE UPLOAD] Signature created:', signature.substring(0, 20) + '...')


### PR DESCRIPTION
The error "Cannot call a class as a function" revealed that PrivateKey must be instantiated with the new keyword. Updated the fallback to use:
  new PrivateKey(postingKey)
instead of:
  PrivateKey(postingKey)

This should allow the image signing to work properly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)