### PR TITLE
Fix Mute User Button Functionality

### DIFF
--- a/src/components/common/InfiniteList/index.js
+++ b/src/components/common/InfiniteList/index.js
@@ -69,6 +69,7 @@ const InfiniteList = ({
           payoutAt={posts[index].payout_at}
           cashout_time={posts[index].cashout_time}
           scrollIndex={index}
+          type="HIVE"
           // muteTrigger={muteTrigger}
           item={posts[index]}
           selectedPocket={selectedPocket}


### PR DESCRIPTION
The mute user button wasn't working because the PostList component's handleClickMuteDialog function checks if type === 'HIVE' before executing the mute action. The InfiniteList component was missing the type prop when rendering PostList, causing the condition to fail and preventing the mute functionality from working.

Added type="HIVE" prop to PostList in InfiniteList component to match the pattern used in Tags and SearchPosts components.

🤖 Generated with [Claude Code](https://claude.com/claude-code)