### PR TITLE
Fix: Use PrivateKey.fromWif() to parse WIF keys correctly

### DIFF
--- a/src/services/api.js
+++ b/src/services/api.js
@@ -1565,7 +1565,7 @@ export const uploadImageToHiveBlog = async (data, username, postingKey, progress
 
           // Sign the hash with posting private key
           console.log('[HIVE UPLOAD] Signing with posting key...')
-          const privateKey = PrivateKey.fromString ? PrivateKey.fromString(postingKey) : new PrivateKey(postingKey)
+          const privateKey = PrivateKey.fromWif(postingKey)
           console.log('[HIVE UPLOAD] Private key created:', !!privateKey)
 
           // Use Signature.signBufferSha256 to sign the already-computed SHA256 hash


### PR DESCRIPTION
The error "Expected n, got 5K2L8..." showed that the WIF string was being passed directly to the signing function instead of a PrivateKey object.

The @hiveio/hive-js library uses PrivateKey.fromWif() not fromString(). The fromWif() method properly decodes the base58 WIF format and validates the checksum before creating the PrivateKey object.

Changes:
- Replace PrivateKey.fromString() with PrivateKey.fromWif()
- Remove fallback logic as fromWif() is the correct static method

🤖 Generated with [Claude Code](https://claude.com/claude-code)