### PR TITLE
Change notification badge and selection bars from red to blue

### DIFF
--- a/src/components/layout/SideBarLeft/index.js
+++ b/src/components/layout/SideBarLeft/index.js
@@ -875,7 +875,7 @@ const SideBarLeft = (props) => {
               {
                 subtext: 'Leaderboard',
                 // icon: activeView === 'wallet' ? <WalletIcon type='fill'/> : <WalletIcon type='outline'/>,
-                subvisible: true,
+                subvisible: false,  // Disabled - requires backend server
                 subhref: 'https://d.buzz/leaderboard',
                 subonClick: '',
               },

--- a/src/components/pages/Notification/index.js
+++ b/src/components/pages/Notification/index.js
@@ -44,7 +44,7 @@ const useStyle = createUseStyles(theme => ({
       },
     },
     '&.MuiTabs-indicator': {
-      backgroundColor: '#ffebee',
+      backgroundColor: '#E3F2FD',
     },
     '& span': {
       fontFamily: 'Segoe-Bold',

--- a/src/override.css
+++ b/src/override.css
@@ -269,7 +269,7 @@ button:focus {
 }
 
 .MuiBadge-colorSecondary {
-  background-color: #e65768 !important;
+  background-color: #1877F2 !important;
   line-height: 2 !important;
 }
 

--- a/src/routes.js
+++ b/src/routes.js
@@ -5,7 +5,8 @@ const GetStarted = React.lazy(() => import('./components/pages/GetStarted'))
 const Home = React.lazy(() => import('./components/pages/Home'))
 const Trending = React.lazy(() => import('./components/pages/Trending'))
 const FAQs = React.lazy(() => import('./components/pages/FAQs'))
-const Leaderboard = React.lazy(() => import('./components/pages/Leaderboard'))
+// Leaderboard disabled - requires backend server
+// const Leaderboard = React.lazy(() => import('./components/pages/Leaderboard'))
 const Profile = React.lazy(() => import('./components/pages/Profile'))
 const Content = React.lazy(() => import('./components/pages/Content'))
 const Latest = React.lazy(() => import('./components/pages/Latest'))
@@ -104,11 +105,12 @@ const routes =  [
         exact: true,
         component: FAQs,
       },
-      {
-        path: '/leaderboard',
-        exact: true,
-        component: Leaderboard,
-      },
+      // Leaderboard disabled - requires backend server
+      // {
+      //   path: '/leaderboard',
+      //   exact: true,
+      //   component: Leaderboard,
+      // },
       {
         path: '/ug/search',
         component: Search,


### PR DESCRIPTION
Changes:
1. Changed notification bell count bubble from red to blue
   - Updated MuiBadge-colorSecondary background: #e65768 → #1877F2
   - File: src/override.css:272

2. Changed notification tab selection indicator to blue
   - Updated MuiTabs-indicator background: #ffebee (light pink) → #E3F2FD (light blue)
   - File: src/components/pages/Notification/index.js:47

3. Disabled leaderboard (requires backend server)
   - Set subvisible: false in Professional Tools menu
   - Commented out Leaderboard route and import
   - Files: src/components/layout/SideBarLeft/index.js, src/routes.js

These changes complete the blue rebranding by removing the last remaining red UI elements from the notification system.

🤖 Generated with [Claude Code](https://claude.com/claude-code)