### PR TITLE
Complete blue rebranding by removing all remaining red colors

### DIFF
--- a/src/components/common/ImageCropper/index.js
+++ b/src/components/common/ImageCropper/index.js
@@ -51,11 +51,11 @@ const useStyles = createUseStyles(theme => ({
     color: '#ffffff',
 
     '&:hover': {
-      background: '#B71C1C',
+      background: '#0D47A1',
     },
 
     '&:active': {
-      background: '#B71C1C !important',
+      background: '#0D47A1 !important',
     },
   },
   cancelButton: {

--- a/src/components/layout/DevelopersFrame/index.js
+++ b/src/components/layout/DevelopersFrame/index.js
@@ -16,7 +16,7 @@ import Container from '@material-ui/core/Container'
 const useStyles = createUseStyles({
   nav: {
     height: 80,
-    backgroundColor: '#f83541',
+    backgroundColor: '#42A5F5',
   },
   container: {
     margin: '0 auto',
@@ -34,7 +34,7 @@ const useStyles = createUseStyles({
   heroSection: {
     width: '100%',
     maxHeight: 500,
-    backgroundColor: '#f83541',
+    backgroundColor: '#42A5F5',
     paddingTop: '4rem',
     backgroundSize: '85%',
     backgroundRepeat: 'no-repeat',
@@ -45,7 +45,7 @@ const useStyles = createUseStyles({
     bottom: 0,
     width: '100%',
     height: 80,
-    backgroundColor: '#f83541',
+    backgroundColor: '#42A5F5',
   },
   inner: {
     width: '100%',

--- a/src/components/layout/OrganizationAppFrame/index.js
+++ b/src/components/layout/OrganizationAppFrame/index.js
@@ -17,7 +17,7 @@ import {
 const useStyles = createUseStyles({
   nav: {
     height: 80,
-    backgroundColor: '#f83541',
+    backgroundColor: '#42A5F5',
   },
   container: {
     margin: '0 auto',
@@ -35,7 +35,7 @@ const useStyles = createUseStyles({
   heroSection: {
     width: '100%',
     maxHeight: 500,
-    backgroundColor: '#f83541',
+    backgroundColor: '#42A5F5',
     paddingTop: '4rem',
     backgroundSize: '85%',
     backgroundRepeat: 'no-repeat',
@@ -46,7 +46,7 @@ const useStyles = createUseStyles({
     bottom: 0,
     width: '100%',
     height: 80,
-    backgroundColor: '#f83541',
+    backgroundColor: '#42A5F5',
   },
   inner: {
     width: '100%',

--- a/src/components/modals/AddToPocketModal/index.js
+++ b/src/components/modals/AddToPocketModal/index.js
@@ -144,7 +144,7 @@ const useStyles = createUseStyles(theme => ({
         color: '#ffffff',
   
         '&:hover': {
-          background: '#B71C1C',
+          background: '#0D47A1',
         },
       },
     },

--- a/src/components/modals/BuzzConfirmModal/index.js
+++ b/src/components/modals/BuzzConfirmModal/index.js
@@ -82,7 +82,7 @@ const useStyles = createUseStyles(theme => ({
       color: '#ffffff',
 
       '&:hover': {
-        background: '#B71C1C',
+        background: '#0D47A1',
       },
     },
   },

--- a/src/components/modals/CreatePocketModal/index.js
+++ b/src/components/modals/CreatePocketModal/index.js
@@ -94,7 +94,7 @@ const useStyles = createUseStyles(theme => ({
         color: '#ffffff',
   
         '&:hover': {
-          background: '#B71C1C',
+          background: '#0D47A1',
         },
       },
     },

--- a/src/components/modals/DeletePocketConfirmModal/index.js
+++ b/src/components/modals/DeletePocketConfirmModal/index.js
@@ -91,7 +91,7 @@ const useStyles = createUseStyles(theme => ({
         color: '#ffffff',
   
         '&:hover': {
-          background: '#B71C1C',
+          background: '#0D47A1',
         },
       },
     },

--- a/src/components/modals/RemoveFromPocketConfirmModal/index.js
+++ b/src/components/modals/RemoveFromPocketConfirmModal/index.js
@@ -98,7 +98,7 @@ const useStyles = createUseStyles(theme => ({
         color: '#ffffff',
   
         '&:hover': {
-          background: '#B71C1C',
+          background: '#0D47A1',
         },
       },
     },

--- a/src/components/modals/SaveDraftModal/index.js
+++ b/src/components/modals/SaveDraftModal/index.js
@@ -36,7 +36,7 @@ const useStyles = createUseStyles(theme => ({
     color: 'white',
     cursor: 'pointer',
     '&:hover': {
-      background: '#B71C1C',
+      background: '#0D47A1',
     },
   },
   titleBox: {

--- a/src/components/modals/SettingsModal/index.js
+++ b/src/components/modals/SettingsModal/index.js
@@ -101,7 +101,7 @@ const useStyles = createUseStyles(theme => ({
           minWidth: 100,
 
           '&:hover': {
-            background: '#B71C1C',
+            background: '#0D47A1',
           },
         },
 
@@ -140,7 +140,7 @@ const useStyles = createUseStyles(theme => ({
 
       '&:hover': {
         padding: '5px 15px',
-        background: '#B71C1C',
+        background: '#0D47A1',
       },
     },
 

--- a/src/components/pages/Developers/index.js
+++ b/src/components/pages/Developers/index.js
@@ -48,9 +48,9 @@ const useStyles = createUseStyles(theme => ({
     },
   },
   currentLink: {
-    borderLeft: '3px solid #FF625E',
+    borderLeft: '3px solid #42A5F5',
     '& a': {
-      color: '#f83541 !important',
+      color: '#1877F2 !important',
     },
   },
 }))

--- a/src/components/pages/Disclaimer/index.js
+++ b/src/components/pages/Disclaimer/index.js
@@ -48,9 +48,9 @@ const useStyles = createUseStyles(theme => ({
     },
   },
   currentLink: {
-    borderLeft: '3px solid #FF625E',
+    borderLeft: '3px solid #42A5F5',
     '& a': {
-      color: '#f83541 !important',
+      color: '#1877F2 !important',
     },
   },
   innerWrapper: {

--- a/src/components/pages/FAQs/index.js
+++ b/src/components/pages/FAQs/index.js
@@ -52,9 +52,9 @@ const useStyles = createUseStyles(theme => ({
     },
   },
   currentLink: {
-    borderLeft: '3px solid #FF625E',
+    borderLeft: '3px solid #42A5F5',
     '& a': {
-      color: '#f83541 !important',
+      color: '#1877F2 !important',
     },
   },
   innerWrapper: {

--- a/src/components/pages/GetStarted/index.js
+++ b/src/components/pages/GetStarted/index.js
@@ -53,9 +53,9 @@ const useStyles = createUseStyles(theme => ({
     },
   },
   currentLink: {
-    borderLeft: '3px solid #FF625E',
+    borderLeft: '3px solid #42A5F5',
     '& a': {
-      color: '#f83541 !important',
+      color: '#1877F2 !important',
     },
   },
   innerWrapper: {

--- a/src/components/pages/PrivacyPolicy/index.js
+++ b/src/components/pages/PrivacyPolicy/index.js
@@ -48,9 +48,9 @@ const useStyles = createUseStyles(theme => ({
     },
   },
   currentLink: {
-    borderLeft: '3px solid #FF625E',
+    borderLeft: '3px solid #42A5F5',
     '& a': {
-      color: '#f83541 !important',
+      color: '#1877F2 !important',
     },
   },
   innerWrapper: {

--- a/src/components/pages/TermsConditions/index.js
+++ b/src/components/pages/TermsConditions/index.js
@@ -48,9 +48,9 @@ const useStyles = createUseStyles(theme => ({
     },
   },
   currentLink: {
-    borderLeft: '3px solid #FF625E',
+    borderLeft: '3px solid #42A5F5',
     '& a': {
-      color: '#f83541 !important',
+      color: '#1877F2 !important',
     },
   },
   innerWrapper: {

--- a/src/components/sections/CreateBuzzForm/index.js
+++ b/src/components/sections/CreateBuzzForm/index.js
@@ -314,7 +314,7 @@ const useStyles = createUseStyles(theme => ({
     },
 
     '&:hover:enabled': {
-      background: '#B71C1C',
+      background: '#0D47A1',
     },
   },
   imageAlert: {


### PR DESCRIPTION
Changed all remaining red color instances to blue theme colors:
- Button hover states: #B71C1C → #0D47A1 (dark blue)
- Layout backgrounds: #f83541 → #42A5F5 (light blue)
- Navigation borders: #FF625E → #42A5F5 (light blue)
- Link colors: #f83541 → #1877F2 (Facebook blue)

Modified components:
- CreateBuzzForm: Publish button hover state
- ImageCropper: Done button hover and active states
- Modal dialogs: BuzzConfirm, SaveDraft, AddToPocket, RemoveFromPocket, DeletePocket, CreatePocket
- Settings modal: Button hover states
- Layout frames: DevelopersFrame and OrganizationAppFrame headers/footers
- Static pages: FAQs, Privacy Policy, Get Started, Developers, Terms & Conditions, Disclaimer

All UI elements now consistently use the blue color scheme.

🤖 Generated with [Claude Code](https://claude.com/claude-code)